### PR TITLE
Make xpath filter more precise so that it returns https URIs

### DIFF
--- a/bin/nvd_downloader
+++ b/bin/nvd_downloader
@@ -53,9 +53,9 @@ response = fetch_page('https://nvd.nist.gov/download.cfm')
 
 if response.is_a?(Net::HTTPSuccess)
   @doc = Nokogiri::HTML(response.body)
-  xml_file_path = '//td[@class="xml-file-type file-20"]'
-  @doc.xpath('//html').xpath(xml_file_path).each do |td|
-    link = td.xpath('a').first['href']
+  xml_file_path = '//tr[@class="xml-feed-data-row"]/td[@class="xml-file-type file-20"]/a[text() = "https"]/@href'
+  @doc.xpath('//html').xpath(xml_file_path).each do |href|
+    link = href.value
     next unless link =~ /.gz$/
 
     dest_path = dest_path(link)


### PR DESCRIPTION
NVD now redirects (HTTP 301) all http requests to https. The 'download_file()' method in nvd_downloader fails with ''redirected to #{location}" in such case.
My patch introduces a bit more precise xpath filter so that we scrap only https URIs which fixes the issue.