### PR TITLE
[WIP] Add first draft of Dockerized cve_server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.2.3
 MAINTAINER Jonathan Claudius
 COPY . /app
 RUN apt-get update && \
-    apt-get install -y build-essential libreadline-dev libssl-dev libpq5 libpq-dev libreadline5 libsqlite3-dev libpcap-dev git-core autoconf postgresql pgadmin3 curl zlib1g-dev libxml2-dev libxslt1-dev vncviewer libyaml-dev curl zlib1g-dev rubygems ruby-dev
+    apt-get install -y build-essential libreadline-dev libssl-dev libreadline5 libsqlite3-dev libpcap-dev git-core autoconf curl zlib1g-dev libxml2-dev libxslt1-dev libyaml-dev curl zlib1g-dev rubygems ruby-dev
 RUN apt-get install -y bc git mongodb
 CMD service mongodb start && \
     mkdir test && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.2.3
+MAINTAINER Jonathan Claudius
+COPY . /app
+RUN apt-get update && \
+    apt-get install -y build-essential libreadline-dev libssl-dev libpq5 libpq-dev libreadline5 libsqlite3-dev libpcap-dev git-core autoconf postgresql pgadmin3 curl zlib1g-dev libxml2-dev libxslt1-dev vncviewer libyaml-dev curl zlib1g-dev rubygems ruby-dev
+RUN apt-get install -y bc git mongodb
+CMD service mongodb start && \
+    mkdir test && \
+    cd test && \
+    curl --ssl -s https://raw.githubusercontent.com/SpiderLabs/cve_server/master/scripts/install.sh | bash -


### PR DESCRIPTION
This isn't quite production ready...

- Should really be a docker-compose.yml with separate DB host
- Should really not use the install script at all and do all the work itself
- Needs to have cron job installed

But, with that said, you can pretty easily build/run a CVE server using the following now...

```
docker build -t cveserver .
docker run -p 9292:9292 -it cveserver:latest /bin/bash
```

I'll send a few more edits to this PR as time permits, but I think this is probably a more viable deployment strategy over the install.sh strategy.  It also opens you up to making it easier for others to consume as well as yourselves.