### PR TITLE
Add CPE exceptions + double encoding support

### DIFF
--- a/config/cpe_exceptions.yml
+++ b/config/cpe_exceptions.yml
@@ -1,0 +1,1 @@
+- joomla:joomla\!

--- a/lib/cve_server/app.rb
+++ b/lib/cve_server/app.rb
@@ -24,7 +24,7 @@ module CVEServer
 
     get '/v1/cpe/:cpe_str' do |cpe_str|
       if params.has_key?('double_encoded_fields') && params['double_encoded_fields']
-        cpe_str = URI.decode(cpe_str)
+        cpe_str = URI.decode(URI.decode(cpe_str))
       end
       # Multiple cpes were included
       if cpe_str.include?(",")
@@ -47,7 +47,7 @@ module CVEServer
 
     get '/v1/cpe_with_version/:cpe_str' do |cpe_str|
       if params.has_key?('double_encoded_fields') && params['double_encoded_fields']
-        cpe_str = URI.decode(cpe_str)
+        cpe_str = URI.decode(URI.decode(cpe_str))
       end
       # Multiple cpes were included
       if cpe_str.include?(",")

--- a/lib/cve_server/app.rb
+++ b/lib/cve_server/app.rb
@@ -23,7 +23,9 @@ module CVEServer
     end
 
     get '/v1/cpe/:cpe_str' do |cpe_str|
-      cpe_str = URI.decode(cpe_str) if params.dig('double_encoded_fields')
+      if params.has_key?('double_encoded_fields') && params['double_encoded_fields']
+        cpe_str = URI.decode(cpe_str)
+      end
       # Multiple cpes were included
       if cpe_str.include?(",")
         bad_request unless valid_cpes?(cpe_str)
@@ -44,7 +46,9 @@ module CVEServer
     end
 
     get '/v1/cpe_with_version/:cpe_str' do |cpe_str|
-      cpe_str = URI.decode(cpe_str) if params.dig('double_encoded_fields')
+      if params.has_key?('double_encoded_fields') && params['double_encoded_fields']
+        cpe_str = URI.decode(cpe_str)
+      end
       # Multiple cpes were included
       if cpe_str.include?(",")
         bad_request unless valid_cpes_with_version?(cpe_str)

--- a/lib/cve_server/app.rb
+++ b/lib/cve_server/app.rb
@@ -23,6 +23,7 @@ module CVEServer
     end
 
     get '/v1/cpe/:cpe_str' do |cpe_str|
+      cpe_str = URI.decode(cpe_str) if params.dig('double_encoded_fields')
       # Multiple cpes were included
       if cpe_str.include?(",")
         bad_request unless valid_cpes?(cpe_str)
@@ -43,6 +44,7 @@ module CVEServer
     end
 
     get '/v1/cpe_with_version/:cpe_str' do |cpe_str|
+      cpe_str = URI.decode(cpe_str) if params.dig('double_encoded_fields')
       # Multiple cpes were included
       if cpe_str.include?(",")
         bad_request unless valid_cpes_with_version?(cpe_str)

--- a/lib/cve_server/config.rb
+++ b/lib/cve_server/config.rb
@@ -31,6 +31,14 @@ module CVEServer
       end
     end
 
+    def cpe_exceptions
+      begin
+        YAML.load_file(File.join(root, 'config', 'cpe_exceptions.yml')) || []
+      rescue Errno::ENOENT
+        []
+      end
+    end
+
     private
 
     def db_settings

--- a/lib/cve_server/cve.rb
+++ b/lib/cve_server/cve.rb
@@ -19,7 +19,7 @@ module CVEServer
     end
 
     def self.all_cpe_equal(cpe)
-      all(cpes: /^#{cpe}$/i).collect do |h|
+      all(cpes: /^#{Regexp.escape(cpe)}$/i).collect do |h|
         h['id']
       end.uniq.sort
     end
@@ -31,7 +31,7 @@ module CVEServer
     end
 
     def self.all_cpe_with_version_equal(cpe)
-      all(cpes_with_version: /^#{cpe}$/i).collect do |h|
+      all(cpes_with_version: /^#{Regexp.escape(cpe)}$/i).collect do |h|
         h['id']
       end.uniq.sort
     end

--- a/lib/cve_server/helper.rb
+++ b/lib/cve_server/helper.rb
@@ -1,3 +1,5 @@
+require 'cve_server/config'
+
 module CVEServer
   module Helper
     module_function
@@ -8,6 +10,8 @@ module CVEServer
     end
 
     def valid_cpe?(cpe)
+      config = CVEServer::Config.new
+      return true if config.cpe_exceptions.include? cpe
       cpe.match(/^[a-z0-9_\%\~\.\-]+\:[a-z0-9_\%\~\.\-]+$/i)
     end
 


### PR DESCRIPTION
The CPE 2.2 and CPE 2.3 specifications prohibit certain special characters from inclusion in the vendor and product names of a CPE, and instead make use URI-encoding of these special characters.
One such example is product part of a particular CPE for Joomla, which according to the CPE specifications should not contain the literal \! which should instead be encoded as %21.
 
Example: [cpe:2.3:a :joomla:joomla\!:1.0.15:*:*:*:*:*:*:*](https://nvd.nist.gov/products/cpe/search/results?keyword=cpe%3a2.3%3aa%3ajoomla%3ajoomla%5c!%3a*%3a*%3a*%3a*%3a*%3a*%3a*%3a*&status=FINAL,DEPRECATED&orderBy=CPEURI&namingFormat=2.3)
 
This is troublesome particularly when trying to include this CPE in the path segment, eg. http://0.0.0.0:9292/v1/cpe/joomla:joomla\!

To mitigate this, we can send a double-encoded version of the subset fields to the cpe server, specifying it as such in the request's query parameters. eg. http://0.0.0.0:9292/v1/cpe/joomla:joomla%255C!,some:other_app?double_encoded_fields=true

Additionally, this we need to add an exceptions list to handle this edge-case.