### PR TITLE
Escapes the host and proxy_add_x_forwarded_for for the NGINX conf, cl…

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,8 +119,8 @@ server {
   server_name localhost;
   location / {
     proxy_pass http://cve_server;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_buffering off;
   }
 }


### PR DESCRIPTION
It fixes the unescaped variables for the Nginx configuration reported at #64.

Thanks for your bug report @EricSesterhennX41 .
