### PR TITLE
Change JSON schema version to 1.1

### DIFF
--- a/bin/nvd_downloader
+++ b/bin/nvd_downloader
@@ -15,8 +15,8 @@ class NvdDownloader
     abort "Invalid NVD feed names provided: [#{nvd_feed_names.join(',')}]" if (NVD_FEED_NAMES & nvd_feed_names).empty?
     @nvd_feed_type = nvd_feed_type
     @nvd_feed_names = nvd_feed_names
-    # CveServer supports only XML schema version 2.0 and JSON schema version 1.0 NVD Data Feeds
-    @schema_version = (@nvd_feed_type == :json) ? '1.0' : '2.0'
+    # CveServer supports only XML schema version 2.0 and JSON schema version 1.1 NVD Data Feeds
+    @schema_version = (@nvd_feed_type == :json) ? '1.1' : '2.0'
   end
 
   # @param [Array<String>]  args


### PR DESCRIPTION
## Add support for JSON 1.1
From NVD website (https://nvd.nist.gov/General/News/JSON-1-1-Vulnerability-Feed-Release):
The JSON 1.1 data feeds will be available on September 9th, 2019.  At that time the current JSON 1.0 data feeds will no longer available.

Relevant links:
* https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog
* https://nvd.nist.gov/General/News/JSON-1-1-Vulnerability-Feed-Release

The MR makes the bin/nvd_downloader to fetch a different URL, for example:
https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.json.gz (new)
vs
https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-2018.json.gz (old)

In that example, if we download & parse the file there's a different result for CVE-2018-5744.

Evidence:

![JSON_1 0](https://user-images.githubusercontent.com/14286143/68490626-fa475d00-020e-11ea-9694-03044684a20f.png)

![JSON_1 1](https://user-images.githubusercontent.com/14286143/68490627-fa475d00-020e-11ea-9636-d2c8ceda4b4b.png)
