### PR TITLE
Removing no_cursor_timeout

### DIFF
--- a/lib/cve_server/db/mongo.rb
+++ b/lib/cve_server/db/mongo.rb
@@ -44,7 +44,7 @@ module CVEServer
       end
 
       def map_reduce(mapper, reducer, options = {})
-        db[@collection].find({}, no_cursor_timeout: true).map_reduce(mapper, reducer, options).execute
+        db[@collection].find({}).map_reduce(mapper, reducer, options).execute
       end
 
       def remove_id(record)


### PR DESCRIPTION
This flag isn't available on newer versions of mongodb (ex 4.4), causing cpe list to become empty.